### PR TITLE
Add README for legacy redirects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,7 +84,7 @@ kramdown:
 # Lazy Images ("enabled" or "disabled")
 lazyimages: "disabled"
 
-exclude: [changelog.md, LICENSE.txt, README.md, Gemfile, Gemfile.lock, .idea, blog_index.json]
+exclude: [changelog.md, LICENSE.txt, README.md, "*/README.md", Gemfile, Gemfile.lock, .idea, blog_index.json]
 
 search:
   namespace: "blog"

--- a/post/README.md
+++ b/post/README.md
@@ -1,0 +1,2 @@
+# Legacy redirects
+Static redirects for URLs on old Tumblr-based blog.vespa.ai - no need to update unless old posts are moved to new location. Redirects are implemented using HTML meat header redirects and should work on most modern browsers.


### PR DESCRIPTION
Adding README to explain legacy blog redirects directory.