### PR TITLE
Add work-around for missing Webrick in Ruby 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,6 @@ end
 # used in _plugins/vespa_index_generator.rb
 gem 'json'
 gem 'nokogiri'
+
+# Work-around for webrick no longer included in Ruby 3.0 (https://github.com/jekyll/jekyll/issues/8523)
+gem "webrick"


### PR DESCRIPTION
@kkraune or @bratseth : Please review.