### PR TITLE
Add link to post in title in mail template

### DIFF
--- a/latest.html
+++ b/latest.html
@@ -7,7 +7,8 @@ permalink: latest.html
 <div class="mcnTextContent" style="padding: 0 18px 9px 18px">
 
     <!-- Post Title -->
-    <h1>{{ post.title }}</h1>
+    <h1><a href="{{ site.url }}{{ post.url }}"
+           style="text-decoration: none; color: #222222; font-weight: bold"">{{ post.title }}</a></h1>
 
     <!-- Author -->
     {%- if post.author %}


### PR DESCRIPTION
- The styling _could_ be added to screen.css instead, maybe, but not sure if that would make it easier to track
- we have not added any of site.url/baseurl to _config.yml so not sure if this expands right on the site (it does locally), let's see if we need to add to config, once out