### PR TITLE
Improve alignment of blog images on front page

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -796,6 +796,9 @@ iframe {
 
 .card .img-fluid {
     width: 100%;
+    max-height: 230px;
+    object-fit: cover;
+    object-position: bottom;
 }
 
 .sticky-top-80 {


### PR DESCRIPTION
Making images on front-page uniform to be more similar to main page (https://vespa.ai) look and feel with the cards being uniform.

@kkraune Please review and merge.

<img width="2905" alt="image" src="https://user-images.githubusercontent.com/62418/231761907-d1db54cc-a5ec-4374-bd05-754d1a468ef2.png">
