### PR TITLE
Remove dead link

### DIFF
--- a/_posts/2023-02-03-improving-text-ranking-with-few-shot-prompting.md
+++ b/_posts/2023-02-03-improving-text-ranking-with-few-shot-prompting.md
@@ -191,7 +191,8 @@ and detailed"_ phrase. Without it, many eyeballed queries were too
 generic. Changing the prompt made the model produce more specific
 queries. The change in output quality is an example of the magic of *prompt engineering*.
 
-We use three first trec-covid [test queries](https://ir.nist.gov/trec-covid/data/topics-rnd5.xml) 
+We use the three first trec-covid test queries (originally from
+https://ir.nist.gov/trec-covid/data/topics-rnd5.xml, which is not available anymore)
 as our in-domain examples for few-shot instruction examples. 
 We pick the first document annotated
 as highly relevant to form the complete query-document example.


### PR DESCRIPTION
ir.nist.gov seems to be dead, couldn't find out where it has moved to either