### PR TITLE
Clean up image credit CSS and fix postbox image alignment

### DIFF
--- a/_includes/postbox.html
+++ b/_includes/postbox.html
@@ -13,8 +13,7 @@
 
                 {% endif %}
             </a>
-            <!--style>.image-credit > a { color: mediumseagreen!important; }</style-->
-            <p class="image-credit" style="font-size: 10px; text-align: left; margin-top: 2px; color: lightgray;">
+            <p class="image-credit">
                 {{ post.image_credit }}</p>
         </div>
         <div class="card-body">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -16,6 +16,19 @@
     margin-top: 10px;
 }
 
+.card .image-credit {
+  font-size: 10px;
+  text-align: left;
+  margin-top: 2px;
+  margin-left: 2px;
+  color: lightgray;
+}
+
+.card .img-fluid {
+    height: 230px;
+    object-position: center;
+}
+
 .subscribebtn-header {
   float: right;
 }


### PR DESCRIPTION
@kkraune Please review. Did a small CSS clean-up to have image credits in separate style as well as making front-page images align better IMO:

<img width="700" alt="image" src="https://github.com/vespa-engine/blog/assets/62418/b547aac7-7be8-4519-bd70-dacbff382afc">
