### PR TITLE
Fallback to title if no synthetic questions are generated

### DIFF
--- a/feed-split.py
+++ b/feed-split.py
@@ -193,7 +193,8 @@ def main():
         id = op['put']
         if id in questions_expansion:
             op['fields']['questions'] = questions_expansion[id]
-
+        else: 
+            op['fields']['questions'] = [op['fields']['title']]
     with open("paragraph_index.json", "w") as fp:
         json.dump(operations, fp)
 


### PR DESCRIPTION
With semantic scoring over the generated questions, text fragments without synthetic questions are unfairly treated. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
