### PR TITLE
Change background and syntax

### DIFF
--- a/_sass/_syntax.scss
+++ b/_sass/_syntax.scss
@@ -1,68 +1,69 @@
-
+// From https://raw.githubusercontent.com/jwarby/pygments-css/master/default.css
 .highlight {
-	background: #fff;
+	background: rgba(0,0,0,.075);
     border: 0;
     padding: 0;
     margin-bottom:1.7rem;
-	.c { color: #999988; font-style: italic } /* Comment */
-	.err { color: #a61717; background-color: #e3d2d2 } /* Error */
-	.k { font-weight: bold } /* Keyword */
-	.o { font-weight: bold } /* Operator */
-	.cm { color: #999988; font-style: italic } /* Comment.Multiline */
-	.cp { color: #999999; font-weight: bold } /* Comment.Preproc */
-	.c1 { color: #999988; font-style: italic } /* Comment.Single */
-	.cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
-	.gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
-	.gd .x { color: #000000; background-color: #ffaaaa } /* Generic.Deleted.Specific */
+	.c { color: #408080; font-style: italic } /* Comment */
+	.err { border: 1px solid #FF0000 } /* Error */
+	.k { color: #008000; font-weight: bold } /* Keyword */
+	.o { color: #666666 } /* Operator */
+	.cm { color: #408080; font-style: italic } /* Comment.Multiline */
+	.cp { color: #BC7A00 } /* Comment.Preproc */
+	.c1 { color: #408080; font-style: italic } /* Comment.Single */
+	.cs { color: #408080; font-style: italic } /* Comment.Special */
+	.gd { color: #A00000 } /* Generic.Deleted */
 	.ge { font-style: italic } /* Generic.Emph */
-	.gr { color: #aa0000 } /* Generic.Error */
-	.gh { color: #999999 } /* Generic.Heading */
-	.gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
-	.gi .x { color: #000000; background-color: #aaffaa } /* Generic.Inserted.Specific */
-	.go { color: #888888 } /* Generic.Output */
-	.gp { color: #555555 } /* Generic.Prompt */
+	.gr { color: #FF0000 } /* Generic.Error */
+	.gh { color: #000080; font-weight: bold } /* Generic.Heading */
+	.gi { color: #00A000 } /* Generic.Inserted */
+	.go { color: #808080 } /* Generic.Output */
+	.gp { color: #000080; font-weight: bold } /* Generic.Prompt */
 	.gs { font-weight: bold } /* Generic.Strong */
-	.gu { color: #aaaaaa } /* Generic.Subheading */
-	.gt { color: #aa0000 } /* Generic.Traceback */
-	.kc { font-weight: bold } /* Keyword.Constant */
-	.kd { font-weight: bold } /* Keyword.Declaration */
-	.kp { font-weight: bold } /* Keyword.Pseudo */
-	.kr { font-weight: bold } /* Keyword.Reserved */
-	.kt { color: #445588; font-weight: bold } /* Keyword.Type */
-	.m { color: #009999 } /* Literal.Number */
-	.s { color: #d14 } /* Literal.String */
-	.na { color: #008080 } /* Name.Attribute */
-	.nb { color: #0086B3 } /* Name.Builtin */
-	.nc { color: #445588; font-weight: bold } /* Name.Class */
-	.no { color: #008080 } /* Name.Constant */
-	.ni { color: #800080 } /* Name.Entity */
-	.ne { color: #990000; font-weight: bold } /* Name.Exception */
-	.nf { color: #990000; font-weight: bold } /* Name.Function */
-	.nn { color: #555555 } /* Name.Namespace */
-	.nt { color: #000080 } /* Name.Tag */
-	.nv { color: #008080 } /* Name.Variable */
-	.ow { font-weight: bold } /* Operator.Word */
+	.gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+	.gt { color: #0040D0 } /* Generic.Traceback */
+	.kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+	.kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+	.kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+	.kp { color: #008000 } /* Keyword.Pseudo */
+	.kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+	.kt { color: #B00040 } /* Keyword.Type */
+	.m { color: #666666 } /* Literal.Number */
+	.s { color: #BA2121 } /* Literal.String */
+	.na { color: #7D9029 } /* Name.Attribute */
+	.nb { color: #008000 } /* Name.Builtin */
+	.nc { color: #0000FF; font-weight: bold } /* Name.Class */
+	.no { color: #880000 } /* Name.Constant */
+	.nd { color: #AA22FF } /* Name.Decorator */
+	.ni { color: #999999; font-weight: bold } /* Name.Entity */
+	.ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+	.nf { color: #0000FF } /* Name.Function */
+	.nl { color: #A0A000 } /* Name.Label */
+	.nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+	.nt { color: #008000; font-weight: bold } /* Name.Tag */
+	.nv { color: #19177C } /* Name.Variable */
+	.ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
 	.w { color: #bbbbbb } /* Text.Whitespace */
-	.mf { color: #009999 } /* Literal.Number.Float */
-	.mh { color: #009999 } /* Literal.Number.Hex */
-	.mi { color: #009999 } /* Literal.Number.Integer */
-	.mo { color: #009999 } /* Literal.Number.Oct */
-	.sb { color: #d14 } /* Literal.String.Backtick */
-	.sc { color: #d14 } /* Literal.String.Char */
-	.sd { color: #d14 } /* Literal.String.Doc */
-	.s2 { color: #d14 } /* Literal.String.Double */
-	.se { color: #d14 } /* Literal.String.Escape */
-	.sh { color: #d14 } /* Literal.String.Heredoc */
-	.si { color: #d14 } /* Literal.String.Interpol */
-	.sx { color: #d14 } /* Literal.String.Other */
-	.sr { color: #009926 } /* Literal.String.Regex */
-	.s1 { color: #d14 } /* Literal.String.Single */
-	.ss { color: #990073 } /* Literal.String.Symbol */
-	.bp { color: #999999 } /* Name.Builtin.Pseudo */
-	.vc { color: #008080 } /* Name.Variable.Class */
-	.vg { color: #008080 } /* Name.Variable.Global */
-	.vi { color: #008080 } /* Name.Variable.Instance */
-	.il { color: #009999 } /* Literal.Number.Integer.Long */
+	.mf { color: #666666 } /* Literal.Number.Float */
+	.mh { color: #666666 } /* Literal.Number.Hex */
+	.mi { color: #666666 } /* Literal.Number.Integer */
+	.mo { color: #666666 } /* Literal.Number.Oct */
+	.sb { color: #BA2121 } /* Literal.String.Backtick */
+	.sc { color: #BA2121 } /* Literal.String.Char */
+	.sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+	.s2 { color: #BA2121 } /* Literal.String.Double */
+	.se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+	.sh { color: #BA2121 } /* Literal.String.Heredoc */
+	.si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+	.sx { color: #008000 } /* Literal.String.Other */
+	.sr { color: #BB6688 } /* Literal.String.Regex */
+	.s1 { color: #BA2121 } /* Literal.String.Single */
+	.ss { color: #19177C } /* Literal.String.Symbol */
+	.bp { color: #008000 } /* Name.Builtin.Pseudo */
+	.vc { color: #19177C } /* Name.Variable.Class */
+	.vg { color: #19177C } /* Name.Variable.Global */
+	.vi { color: #19177C } /* Name.Variable.Instance */
+	.il { color: #666666 } /* Literal.Number.Integer.Long */
 }
 
 td.rouge-code { width: 100%;}


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

I suggest some visual updates to the syntax highlighting. 
It is a bit difficult to see what is code and what is text. 
A bit better syntax highlighting makes it much more comfortable to read imho.

## Old

<img width="596" alt="image" src="https://github.com/vespa-engine/blog/assets/24563696/d0e582c0-f873-442e-abdf-ee78fb7da2ce">
<img width="514" alt="image" src="https://github.com/vespa-engine/blog/assets/24563696/dfd51c24-3507-49ca-8c6d-022c1767636e">

## This
<img width="608" alt="image" src="https://github.com/vespa-engine/blog/assets/24563696/0d356d64-76ac-4333-a3b7-1044db1fb290">
<img width="628" alt="image" src="https://github.com/vespa-engine/blog/assets/24563696/69c2bfb7-94b5-4e10-ac43-6f4daebf32a6">

Suggested style is taken from Pygments "default" theme. If others are preferred, they can be viewed [here](https://jwarby.github.io/jekyll-pygments-themes/languages/java.html). 

